### PR TITLE
Disable Helmfile upgrade check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/helmfile:latest
             ghcr.io/${{ github.repository_owner }}/helmfile:${{ env.TAG }}
 
+      - name: Run Version
+        # as push and load may not be set together at the moment
+        # we can only run this step in non-release builds
+        if: github.event_name != 'release'
+        run: |
+          docker run ghcr.io/${{ github.repository_owner }}/helmfile:latest helmfile version
+
       - name: Inspect
         # as push and load may not be set together at the moment
         # we can only run this step in non-release builds

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ RUN pip3 install -Iv azure-cli==${AZ_VERSION}
 
 RUN pip3 install yq
 
+# Disable Helmfile upgrade check
+
+ENV HELMFILE_UPGRADE_NOTICE_DISABLED="true"
+
 # Remove WORKDIR and ENTRYPOINT FROM base image
 
 WORKDIR /


### PR DESCRIPTION
Starting with version 0.147.0, Helmfile tries to make an upgrade check. As we are using Helmfile in regulated environments, we don't want that. So to disable this, we need to set the environment variable `HELMFILE_UPGRADE_NOTICE_DISABLED` to a non-empty value.