### PR TITLE
Install Postgresql client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install basic packages
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl gnupg lsb-release
+    apt-get --no-install-recommends --yes install \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
@@ -15,8 +22,22 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /
 # Install main packages
 
 RUN apt-get update && \
-    apt-get install -y containerd.io docker-ce docker-ce-cli git jq ncat pwgen python3-pip sudo unzip wget && \
-    apt-get clean
+    apt-get --no-install-recommends --yes install \
+        containerd.io \
+        docker-ce \
+        docker-ce-cli \
+        git \
+        jq \
+        ncat \
+        postgresql-client \
+        pwgen \
+        python3-pip \
+        sudo \
+        unzip \
+        wget \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install PIP packages
 


### PR DESCRIPTION
Needed, because we move the database deployments to the service deployments (similar like it's done for storage with Kubernetes).

Also restructure Dockerfile to improve Git diffs in the future.