### PR TITLE
Allow running Helm with any other user than root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,16 @@ FROM ghcr.io/helmfile/helmfile-ubuntu:v0.148.1
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Allow running with any other user than root.
+# TODO: Remove again when https://github.com/helmfile/helmfile/pull/546 has been merged and released!
+
+ARG HELM_CACHE_HOME="/root/.cache/helm"
+ENV HELM_CACHE_HOME="${HELM_CACHE_HOME}"
+ARG HELM_CONFIG_HOME="/root/.config/helm"
+ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
+ARG HELM_DATA_HOME="/root/.local/share/helm"
+ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
+
 # Install basic packages
 
 RUN apt-get update && \


### PR DESCRIPTION
Helm stores plugins and other data at a specific location. In the Helmfile image, this location is the `/root` directory, which already has been made accessible for other users. But in order for other users to be able to find the installed plugins, the Helm home environment variables need to be set to the fixed `/root` location.

This is a temporary workaround and should be removed again as soon as https://github.com/helmfile/helmfile/pull/546 has been merged and released.